### PR TITLE
ADD: New util scripts for fix some problems with the system boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Actualmente mi OrangePI corre el sistema operativo [Debian Bookworm Server 5.10.
 | RAM           | 4GB LPDDR4      |
 | GPU           | Mali G52 2EE    |
 
-***Nota**: Recomiendo instalar un sistema de refrigerado a la OrangePI ya que la misma suele alcanzar altas temperaturas facilmente.*
+***Nota**: Recomiendo instalar un sistema de refrigerado a la OrangePI ya que la misma suele alcanzar altas temperaturas facilmente. En mi caso uso una carcasa que compre por Amazon, que es la [N510](https://www.amazon.com/-/es/eleUniverse-ventilador-refrigeraci%C3%B3n-disipadores-compatible/dp/B0CJDV7DR8/ref=sr_1_9?__mk_es_US=%C3%85M%C3%85%C5%BD%C3%95%C3%91&crid=1VMLVOQZEDQ6F&dib=eyJ2IjoiMSJ9.6Cmkq787zmIT7_p1h_RySsOyX-i4xBJUWfHE_3WfDtXMZDjtyDLHuTsZc7H5F3UjkJOTGZaJzfEyueWUIWGG7InXShPsvcQCDA66mlxTxQ1RQtgPAxIkSMJSSMI63IqGfeRmmw_g8mmOo0UbHx20FV8rYQTpLQTeSyfRJI1liuoOe3hA6TORMnIZ9QbiNmh2ryDX29Hv0MFvXSMab_uiq6grpuHtM1KdAN0_Rl61yjQ.oKAEDo91p9zJrGvX81_rw58OhWwYabwuT1VwSuyTu-4&dib_tag=se&keywords=orange+pi+3b&qid=1732998555&sprefix=orange+pi+3b%2Caps%2C367&sr=8-9).*
 
 ## Setup:
-Mi homelab fue pensado para ser un sistema multiproposito, con el fin de ser servidor de multimedia, archivos, apps, etc. Todo corriendo sobre **contenedores docker**.
+Mi homelab fue pensado para ser un sistema multiproposito, con el fin de ser servidor de multimedia, archivos, apps, etc. Todo corriendo sobre **contenedores docker**. Para eso me apoyo de **CasaOS** que me permite de manera sencilla tener un dashboard y un "AppStore", que funciona mediante docker compose, ejecutar todo tipo de apps y en caso de que no este disponible alguna que necesite poder crearla de manera simple y rapida.
 
 ### Instalar Docker:
 En este caso instalar Docker lo mejor es seguir la documentacion oficial, en mi caso para Debian.
@@ -28,20 +28,12 @@ Al igual, escribi una breve guia que simplifica todo lo que debes hacer para pod
 - [Guia resumida](https://gist.github.com/Sebas1012/83430da8df4ca4fcc74b0bdd2d559d80)
 
 
+### Instalar CasaOS:
+Instalar CasaOs es sencillo y desde la documentacion oficial se puede hacer de manera muy rapida.
 
-### Servicios usados con Docker:
+- [CasaOs Docs](https://github.com/IceWhaleTech/CasaOS/blob/main/README.md)
 
-- [Homer Dashboard](https://github.com/bastienwirtz/homer)
-- [Portainer](https://www.portainer.io)
-- [Uptime Kuma](https://uptime.kuma.pet)
-- [Pi-hole](https://pi-hole.net)
-- [Duplicati](https://www.duplicati.com)
-- [Homer](https://github.com/bastienwirtz/homer)
-
-### Servicios locales:
-
-- [Cockpit](https://cockpit-project.org) 
-
+ 
 ### Guias de interes: ❗
 
 - [Configurar IP estatica con nmtui](http://www.orangepi.org/orangepiwiki/index.php/How_to_set_a_static_IP_address)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Al igual, escribi una breve guia que simplifica todo lo que debes hacer para pod
 
 
 
-### Servicios usados:
+### Servicios usados con Docker:
 
 - [Homer Dashboard](https://github.com/bastienwirtz/homer)
 - [Portainer](https://www.portainer.io)
@@ -37,6 +37,10 @@ Al igual, escribi una breve guia que simplifica todo lo que debes hacer para pod
 - [Pi-hole](https://pi-hole.net)
 - [Duplicati](https://www.duplicati.com)
 - [Homer](https://github.com/bastienwirtz/homer)
+
+### Servicios locales:
+
+- [Cockpit](https://cockpit-project.org) 
 
 ### Guias de interes: ❗
 

--- a/cmd/fix-rootdelay.sh
+++ b/cmd/fix-rootdelay.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-FILE="/boot/armbianEnv.txt"
-LINE="extraargs=rootdelay=10"
+FILE="/boot/orangepiEnv.txt"
+DELAY_VALUE="10"
 
 echo "Verificando archivo $FILE ..."
 
@@ -17,12 +17,18 @@ fi
 sudo cp "$FILE" "${FILE}.bak"
 echo "Copia de seguridad creada en ${FILE}.bak"
 
-if grep -q "^extraargs=" "$FILE"; then
-    sudo sed -i "s/^extraargs=.*/$LINE/" "$FILE"
-    echo "Línea 'extraargs' actualizada con rootdelay=10"
+if grep -q '^extraargs=' "$FILE"; then
+    echo "Ya existe extraargs, agregando rootdelay si no está presente..."
+    if ! grep -q 'rootdelay=' "$FILE"; then
+        sudo sed -i "s/^extraargs=\"*/&rootdelay=$DELAY_VALUE /" "$FILE"
+        echo "rootdelay agregado."
+    else
+        echo "rootdelay ya está configurado."
+    fi
 else
-    echo "$LINE" | sudo tee -a "$FILE" >/dev/null
-    echo "Línea 'extraargs' agregada al final del archivo"
+    echo "Agregando línea extraargs con rootdelay=$DELAY_VALUE ..."
+    echo "extraargs=\"rootdelay=$DELAY_VALUE\"" | sudo tee -a "$FILE" > /dev/null
+    echo "Línea añadida correctamente."
 fi
 
 echo "Configuración aplicada correctamente"

--- a/cmd/fix-rootdelay.sh
+++ b/cmd/fix-rootdelay.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script para corregir el tiempo de espera de arranque en Armbian
+
+set -e
+
+FILE="/boot/armbianEnv.txt"
+LINE="extraargs=rootdelay=10"
+
+echo "Verificando archivo $FILE ..."
+
+if [ ! -f "$FILE" ]; then
+    echo "No se encontró $FILE"
+    exit 1
+fi
+
+sudo cp "$FILE" "${FILE}.bak"
+echo "Copia de seguridad creada en ${FILE}.bak"
+
+if grep -q "^extraargs=" "$FILE"; then
+    sudo sed -i "s/^extraargs=.*/$LINE/" "$FILE"
+    echo "Línea 'extraargs' actualizada con rootdelay=10"
+else
+    echo "$LINE" | sudo tee -a "$FILE" >/dev/null
+    echo "Línea 'extraargs' agregada al final del archivo"
+fi
+
+echo "Configuración aplicada correctamente"
+echo "Reinicia el sistema con: sudo reboot"

--- a/cmd/fix_rootdelay.sh
+++ b/cmd/fix_rootdelay.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Script para corregir el tiempo de espera de arranque en Armbian
+# Modifica /boot/orangepiEnv.txt para agregar rootdelay
+# Uso: Ejecutar este script, ejecutar sudo update-initramfs -u y finalmente reiniciar el sistema
 
 set -e
 

--- a/cmd/mount_nvme.sh
+++ b/cmd/mount_nvme.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to mount NVMe drive on Armbian system
+# Uso: Ejecutar sudo blkid para obtener el UUID del NVME (Se identifica porque empieza con una estructura similar a /dev/nvme0n1p1) y luego este script para montar el NVMe en /mnt/nvme
+
+UUID_NVME="8354ef4a-1aa5-4696-b86b-9fd2b8703f9a"
+MOUNT_POINT="/mnt/nvme"
+
+if [ ! -d "$MOUNT_POINT" ]; then
+    echo "Creando punto de montaje en $MOUNT_POINT..."
+    sudo mkdir -p "$MOUNT_POINT"
+fi
+
+if mountpoint -q "$MOUNT_POINT"; then
+    echo "El NVMe ya está montado en $MOUNT_POINT."
+else
+    echo "Montando NVMe..."
+    sudo mount UUID=$UUID_NVME "$MOUNT_POINT"
+
+    if [ $? -eq 0 ]; then
+        echo "NVMe montado correctamente en $MOUNT_POINT."
+    else
+        echo "Error al montar el NVMe."
+        exit 1
+    fi
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,73 +1,9 @@
-version: '3'
-
 services:
-  homer:
-    container_name: homer
-    image: b4bz/homer:latest
+  reverse-proxy:
+    image: traefik:v3.2
+    command: --api.insecure=true --providers.docker
     ports:
-      - '8080:8080'
-    volumes:
-      - ./docker/homer:/www/assets
-    restart: always
-    user: 0:0 #! Se debe corregir esta linea.
-
-  portainer:
-    container_name: portainer
-    image: portainer/portainer-ce:latest
-    ports:
-      - '9443:9443'
-      - '8000:8000'
+      - "8081:80"
+      - "9090:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - portainer_data:/data
-    restart: always
-
-  uptime-kuma:
-    container_name: uptime-kuma
-    image: louislam/uptime-kuma:1
-    ports:
-      - '3001:3001'
-    volumes:
-      - uptime-kuma:/app/data
-    restart: always
-
-  pihole:
-    container_name: pihole
-    image: pihole/pihole:latest
-    # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
-    ports:
-      - "53:53/tcp"
-      - "53:53/udp"
-      - "67:67/udp" # Only required if you are using Pi-hole as your DHCP server
-      - "80:80/tcp"
-    environment:
-      TZ: 'America/Bogota'
-      # WEBPASSWORD: 'set a secure password here or it will be random'
-    # Volumes store your data between container upgrades
-    volumes:
-      - './docker/pihole/etc-pihole:/etc/pihole'
-      - './docker/pihole/etc-dnsmasq.d:/etc/dnsmasq.d'
-    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
-    cap_add:
-      - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
-    restart: unless-stopped
-
-  duplicati:
-    container_name: duplicati
-    image: lscr.io/linuxserver/duplicati:latest
-    ports:
-      - 8200:8200
-    volumes:
-      - ./docker/duplicati/config:/config
-      # - /path/to/backups:/backups #TODO: Pendiente por definir.
-      - ./docker:/source
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Bogota
-    restart: unless-stopped
-
-volumes:
-  portainer_data:
-    external: true
-  uptime-kuma:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,23 @@
+name: traefik
 services:
   reverse-proxy:
+    container_name: traefik
     image: traefik:v3.2
+    deploy:
+      resources:
+        reservations:
+          memory: 256M
+    network_mode: bridge
+    restart: unless-stopped
     command: --api.insecure=true --providers.docker
     ports:
-      - "8081:80"
-      - "9090:8080"
+      - target: 80
+        published: "8081"
+        protocol: tcp
+      - target: 8080
+        published: "9090"
+        protocol: tcp
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+x-casaos:
+  icon: https://upload.wikimedia.org/wikipedia/commons/1/1b/Traefik.logo.png


### PR DESCRIPTION
This pull request introduces several updates to the project documentation and configuration, focusing on improving the homelab setup instructions and simplifying the Docker Compose configuration. The main changes include enhanced documentation for cooling recommendations and CasaOS usage, the addition of two utility scripts for Armbian systems, and a major overhaul of the `docker-compose.yml` file to use Traefik as a reverse proxy.

**Documentation improvements:**

* Expanded the cooling recommendation in `README.md` with a specific Amazon case suggestion, and added a detailed explanation of using CasaOS for managing Docker containers, including a link to the official CasaOS documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-L39)

**Utility scripts for Armbian:**

* Added `cmd/fix_rootdelay.sh`, a script to automate adding `rootdelay` to `/boot/orangepiEnv.txt` to fix boot delays on Armbian systems.
* Added `cmd/mount_nvme.sh`, a script to mount an NVMe drive by UUID to `/mnt/nvme` on Armbian systems.

**Docker Compose configuration overhaul:**

* Replaced the previous multi-service setup in `docker-compose.yml` (which included Homer, Portainer, Uptime Kuma, Pi-hole, Duplicati, etc.) with a minimal configuration running only Traefik as a reverse proxy, including resource limits and CasaOS metadata.